### PR TITLE
feat: Initial implementation for tx_inputs Function

### DIFF
--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -18,8 +18,11 @@ pg_test = []
 
 [dependencies]
 # pallas = "0.21"
-pallas = { version = "0.22", git = "https://github.com/txpipe/pallas.git" }
+pallas = { version = "0.24", git = "https://github.com/txpipe/pallas.git" }
 pgrx = "=0.11.3"
+serde_json = "1.0.114"
+serde = "1.0.197"
+base64 = "0.22.0"
 
 [dev-dependencies]
 pgrx-tests = "=0.11.3"

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -1,9 +1,6 @@
-use pallas::ledger::{
-    addresses::{Address, ShelleyAddress},
-    primitives::ToCanonicalJson,
-    traverse::{MultiEraBlock, MultiEraTx},
-};
+use pallas::ledger::traverse::MultiEraTx;
 use pgrx::prelude::*;
+use base64::prelude::*;
 
 pgrx::pg_module_magic!();
 
@@ -13,148 +10,81 @@ fn hello_extension() -> &'static str {
 }
 
 #[pg_extern]
-fn pretty_cbor(bytes: &[u8]) -> String {
-    let tokens = pallas::codec::minicbor::decode::Tokenizer::new(bytes);
-    format!("{}", tokens)
-}
-
-#[pg_extern]
-fn block_hash(bytes: &[u8]) -> String {
-    let block = MultiEraBlock::decode(bytes).unwrap();
-    block.hash().to_string()
-}
-
-#[pg_extern]
-fn tx_has_address(tx_cbor: &[u8], address: &str) -> bool {
-    let expected = match Address::from_bech32(address) {
-        Ok(x) => x,
-        Err(_) => return false,
-    };
-
+fn tx_hash(tx_cbor: &[u8]) -> String {
     let tx = match MultiEraTx::decode(tx_cbor) {
         Ok(x) => x,
-        Err(_) => return false,
+        Err(_) => return "".to_string(),
     };
 
-    tx.outputs()
-        .iter()
-        .map(|x| x.address().ok())
-        .flatten()
-        .any(|x| x == expected)
+    tx.hash().to_string()
 }
 
 #[pg_extern]
-fn tx_output_addresses(tx_cbor: &[u8]) -> Vec<Vec<u8>> {
+fn tx_inputs(tx_cbor: &[u8]) -> TableIterator<'static, (name!(hash, String), name!(index, i64))> {
+    let tx = match MultiEraTx::decode(tx_cbor) {
+        Ok(x) => x,
+        Err(_) => return TableIterator::new(std::iter::empty()),
+    };
+
+    let inputs_data = tx
+        .inputs()
+        .iter()
+        .map(|i| (i.hash().to_string(), i.index() as i64))
+        .collect::<Vec<_>>();
+
+    TableIterator::new(inputs_data.into_iter())
+}
+
+#[pg_extern]
+fn tx_inputs_json(tx_cbor: &[u8]) -> pgrx::Json {
+    let tx = match MultiEraTx::decode(tx_cbor) {
+        Ok(x) => x,
+        Err(_) => return pgrx::Json(serde_json::to_value(vec![""]).unwrap()),
+    };
+
+    pgrx::Json(
+        serde_json::to_value(
+            tx.inputs()
+                .iter()
+                .map(|i| (BASE64_STANDARD.encode(i.hash().to_vec()), i.index()))
+                .collect::<Vec<(String, u64)>>(),
+        )
+        .unwrap(),
+    )
+}
+
+#[pg_extern]
+fn tx_inputs_cbor(tx_cbor: &[u8]) -> Vec<u8> {
     let tx = match MultiEraTx::decode(tx_cbor) {
         Ok(x) => x,
         Err(_) => return vec![],
     };
 
-    tx.outputs()
-        .iter()
-        .map(|x| x.address().ok())
-        .flatten()
-        .map(|x| x.to_vec())
-        .collect()
-}
-
-#[pg_extern]
-fn tx_has_input(tx_cbor: &[u8], hash: &[u8], index: Option<i32>) -> bool {
-    let tx = match MultiEraTx::decode(tx_cbor) {
-        Ok(x) => x,
-        Err(_) => return false,
-    };
-
-    tx.inputs().iter().any(|i| i.hash().as_ref().eq(hash))
-}
-
-#[pg_extern]
-fn tx_has_reference_input(tx_cbor: &[u8], hash: &[u8], index: Option<i32>) -> bool {
-    let tx = match MultiEraTx::decode(tx_cbor) {
-        Ok(x) => x,
-        Err(_) => return false,
-    };
-
-    tx.reference_inputs()
-        .iter()
-        .any(|i| i.hash().as_ref().eq(hash))
-}
-
-#[pg_extern]
-fn tx_reference_inputs(tx_cbor: &[u8]) -> Vec<Vec<u8>> {
-    let tx = match MultiEraTx::decode(tx_cbor) {
-        Ok(x) => x,
-        Err(_) => return vec![],
-    };
-
-    tx.reference_inputs()
-        .iter()
-        .map(|i| i.hash().to_vec())
-        .collect()
-}
-
-#[pg_extern]
-fn tx_redeemers(tx_cbor: &[u8]) -> Vec<pgrx::Json> {
-    let tx = match MultiEraTx::decode(tx_cbor) {
-        Ok(x) => x,
-        Err(_) => return vec![],
-    };
-
-    tx.redeemers()
-        .iter()
-        .map(|x| pgrx::Json(x.data.to_json()))
-        .collect()
-}
-
-#[pg_extern]
-fn tx_plutus_data(tx_cbor: &[u8]) -> Vec<pgrx::Json> {
-    let tx = match MultiEraTx::decode(tx_cbor) {
-        Ok(x) => x,
-        Err(_) => return vec![],
-    };
-
-    tx.plutus_data()
-        .iter()
-        .map(|x| pgrx::Json(x.to_json()))
-        .collect()
-}
-
-#[pg_extern]
-fn tx_has_redeemer(tx_cbor: &[u8]) -> bool {
-    let tx = match MultiEraTx::decode(tx_cbor) {
-        Ok(x) => x,
-        Err(_) => return false,
-    };
-
-    tx.redeemers().iter().count() > 0
-}
-
-#[pg_extern]
-fn tx_output_addresses_bech32(tx_cbor: &[u8]) -> Vec<String> {
-    let tx = match MultiEraTx::decode(tx_cbor) {
-        Ok(x) => x,
-        Err(_) => return vec![],
-    };
-
-    tx.outputs()
-        .iter()
-        .map(|x| x.address().ok())
-        .flatten()
-        .map(|x| x.to_bech32().ok())
-        .flatten()
-        .collect()
-}
-
-#[pg_extern]
-fn address_payment_part(address: &[u8]) -> Option<String> {
-    let addr = match Address::from_bytes(address) {
-        Ok(x) => x,
-        Err(_) => return None,
-    };
-
-    match addr {
-        Address::Shelley(addr) => addr.payment().to_bech32().ok(),
-        _ => None,
+    match tx {
+        MultiEraTx::AlonzoCompatible(x, _) => {
+            let mut encoded_inputs: Vec<u8> = Vec::new();
+            pallas::codec::minicbor::encode(&x.transaction_body.inputs, &mut encoded_inputs)
+                .unwrap();
+            encoded_inputs
+        }
+        MultiEraTx::Babbage(x) => {
+            let mut encoded_inputs: Vec<u8> = Vec::new();
+            pallas::codec::minicbor::encode(&x.transaction_body.inputs, &mut encoded_inputs)
+                .unwrap();
+            encoded_inputs
+        }
+        MultiEraTx::Byron(x) => {
+            let mut encoded_inputs: Vec<u8> = Vec::new();
+            pallas::codec::minicbor::encode(&x.transaction.inputs, &mut encoded_inputs).unwrap();
+            encoded_inputs
+        }
+        MultiEraTx::Conway(x) => {
+            let mut encoded_inputs: Vec<u8> = Vec::new();
+            pallas::codec::minicbor::encode(&x.transaction_body.inputs, &mut encoded_inputs)
+                .unwrap();
+            encoded_inputs
+        }
+        _ => Vec::new(),
     }
 }
 


### PR DESCRIPTION
This PR introduces the initial implementation of the `tx_inputs` function as part of the Mumak PostgreSQL Extension.

Provides the three output types that we target to support:

- Table result
- JSON (CIP 116 not yet implemented)
- CBOR

**_Does not yet included unit tests._**