### PR TITLE
chore: remove pallas specific version to always just refer to latest pallas

### DIFF
--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -18,7 +18,7 @@ pg_test = []
 
 [dependencies]
 # pallas = "0.21"
-pallas = { version = "0.28", git = "https://github.com/txpipe/pallas.git" }
+pallas = { git = "https://github.com/txpipe/pallas.git" }
 pgrx = "=0.11.3"
 serde_json = "1.0.114"
 serde = "1.0.197"


### PR DESCRIPTION
This PR removes pallas specific version in `cargo.toml`